### PR TITLE
Update shortened apt get to full key

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ when "ubuntu"
   default["redis"]["apt_uri"]                   = "http://ppa.launchpad.net/chris-lea/redis-server/ubuntu"
   default["redis"]["apt_components"]            = ["main"]
   default["redis"]["apt_keyserver"]             = "keyserver.ubuntu.com"
-  default["redis"]["apt_key"]                   = "C7917B12"
+  default["redis"]["apt_key"]                   = "B9316A7BC7917B12"
 end
 
 default["redis"]["pidfile"]                     = "/var/run/redis/redis-server.pid"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,3 +9,9 @@ apt_repository node["redis"]["apt_repository"] do
   keyserver node["redis"]["apt_keyserver"]
   key node["redis"]["apt_key"]
 end
+
+execute 'apt-get update' do
+  command 'apt-get update'
+  ignore_failure true
+  action :nothing
+end


### PR DESCRIPTION
Replace the ambiguous shortened key with the full key., see https://dev.gnupg.org/T4136

```
$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv C7917B12
Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --homedir /tmp/tmp.BOWqyM0QJo --no-auto-check-trustdb --trust-model always --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv C7917B12
gpg: requesting key C7917B12 from hkp server keyserver.ubuntu.com
gpg: key C7917B12: "Totally Legit Signing Key <mallory@example.org>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1

$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv B9316A7BC7917B12
Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --homedir /tmp/tmp.Q07GG1H5bF --no-auto-check-trustdb --trust-model always --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv B9316A7BC7917B12
gpg: requesting key C7917B12 from hkp server keyserver.ubuntu.com
gpg: key C7917B12: "Launchpad chrislea" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
```